### PR TITLE
SEC-7074: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dave-inc/team-spend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dave-inc/team-spend
+* @dave-inc/team-spend-backend


### PR DESCRIPTION
This PR adds a CODEOWNERS file to assign @dave-inc/team-spend as the default owner for all files in this repository.

## Changes
- Added `.github/CODEOWNERS` file with wildcard rule for @dave-inc/team-spend

## Related Issue
SEC-7074